### PR TITLE
Remove deprecation on mirrors. They can be disabled with parameter

### DIFF
--- a/mirror.scad
+++ b/mirror.scad
@@ -8,23 +8,26 @@
 // mirror_z()
 
 
-module mirror_x() {
+module mirror_x( mirrorx=true ) {
 	union() {
-		child();
-		scale([-1,1,1]) child();
+		children();
+		if ( mirrorx )
+			scale([-1,1,1]) children();
 	}
 }
 
-module mirror_y() {
+module mirror_y( mirrory=true ) {
 	union() {
-		child();
-		scale([1,-1,1]) child();
+		children();
+		if ( mirrory )
+			scale([1,-1,1]) children();
 	}
 }
 
-module mirror_z() {
+module mirror_z( mirrorz=true ) {
 	union() {
-		child();
-		scale([1,1,-1]) child();
+		children();
+		if ( mirrorz )
+			scale([1,1,-1]) children();
 	}
 }


### PR DESCRIPTION
Removed deprecation warning on mirror modules.
Added an option to each mirror function to be able to disable them with an optional parameter.

Regards