### PR TITLE
fix: rename deprecated child() to children()

### DIFF
--- a/mirror.scad
+++ b/mirror.scad
@@ -10,21 +10,21 @@
 
 module mirror_x() {
 	union() {
-		child();
-		scale([-1,1,1]) child();
+		children();
+		scale([-1,1,1]) children();
 	}
 }
 
 module mirror_y() {
 	union() {
-		child();
-		scale([1,-1,1]) child();
+		children();
+		scale([1,-1,1]) children();
 	}
 }
 
 module mirror_z() {
 	union() {
-		child();
-		scale([1,1,-1]) child();
+		children();
+		scale([1,1,-1]) children();
 	}
 }

--- a/morphology.scad
+++ b/morphology.scad
@@ -14,52 +14,52 @@
 
 module outset(d=1) {
 	// Bug workaround for older OpenSCAD versions
-	if (version_num() < 20130424) render() outset_extruded(d) child();
+	if (version_num() < 20130424) render() outset_extruded(d) children();
 	else minkowski() {
 		circle(r=d);
-		child();
+		children();
 	}
 }
 
 module outset_extruded(d=1) {
    projection(cut=true) minkowski() {
         cylinder(r=d);
-        linear_extrude(center=true) child();
+        linear_extrude(center=true) children();
    }
 }
 
 module inset(d=1) {
-	 render() inverse() outset(d=d) inverse() child();
+	 render() inverse() outset(d=d) inverse() children();
 }
 
 module fillet(r=1) {
-	inset(d=r) render() outset(d=r) child();
+	inset(d=r) render() outset(d=r) children();
 }
 
 module rounding(r=1) {
-	outset(d=r) inset(d=r) child();
+	outset(d=r) inset(d=r) children();
 }
 
 module shell(d,center=false) {
 	if (center && d > 0) {
 		difference() {
-			outset(d=d/2) child();
-			inset(d=d/2) child();
+			outset(d=d/2) children();
+			inset(d=d/2) children();
 		}
 	}
 	if (!center && d > 0) {
 		difference() {
-			outset(d=d) child();
-			child();
+			outset(d=d) children();
+			children();
 		}
 	}
 	if (!center && d < 0) {
 		difference() {
-			child();
-			inset(d=-d) child();
+			children();
+			inset(d=-d) children();
 		}
 	}
-	if (d == 0) child();
+	if (d == 0) children();
 }
 
 
@@ -68,7 +68,7 @@ module shell(d,center=false) {
 module inverse() {
 	difference() {
 		square(1e5,center=true);
-		child();
+		children();
 	}
 }
 


### PR DESCRIPTION
https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/User-Defined_Functions_and_Modules#Children

Removes the warning in the console of OpenSCAD :)

