### PR TITLE
fix warnings about operations on undef in trajectory.scad

### DIFF
--- a/trajectory.scad
+++ b/trajectory.scad
@@ -2,22 +2,22 @@ use <so3.scad>
 
 function val(a=undef,default=undef) = a == undef ? default : a;
 function vec_is_undef(x,index_=0) = index_ >= len(x) ? true :
-is_undef(x[index_]) && vec_is_undef(x,index_+1);
+is_undef_or_oob(x[index_]) && vec_is_undef(x,index_+1);
 
-function is_undef(x) = len(x) > 0 ? vec_is_undef(x) : x == undef;
+function is_undef_or_oob(x) = is_undef(x) ? true : is_list(x) ? vec_is_undef(x) : false;
 // Either a or b, but not both
-function either(a,b,default=undef) = is_undef(a) ? (is_undef(b) ? default : b) : is_undef(b) ? a : undef;
+function either(a,b,default=undef) = is_undef_or_oob(a) ? (is_undef_or_oob(b) ? default : b) : is_undef_or_oob(b) ? a : undef;
 
 function translationv(left=undef,right=undef,up=undef,down=undef,forward=undef,backward=undef,translation=undef) = 
 translationv_2(
-	x = either(up,-down),
-	y = either(right,-left),
-	z = either(forward,-backward),
+	       x = either(up,is_undef(down) ? down : -down),
+	       y = either(right,is_undef(left) ? left : -left),
+	       z = either(forward,is_undef(backward) ? backward : -backward),
 	translation = translation);
 
 function translationv_2(x,y,z,translation) =
 	x == undef && y == undef && z == undef ? translation :
-	is_undef(translation) ? [val(x,0),val(y,0),val(z,0)]
+	is_undef_or_oob(translation) ? [val(x,0),val(y,0),val(z,0)]
 	: undef;
 
 function rotationv(pitch=undef,yaw=undef,roll=undef,rotation=undef) = 


### PR DESCRIPTION
I get a bunch of warnings from a library that uses trajectory.scad, so I decided to take a peek. I think I've hardened it against whatever the caller may do.

* instead of redefining `is_undef()` I've renamed it to indicate it also does an Out-Of-Bounds check on vectors
* use the real `is_undef()` prior to doing other operations on potentially undefined values
* use `is_list()` instead of calling `len()` on something that might be scalar
* check for undef before negating

cheers!